### PR TITLE
Set motor variation at proto level

### DIFF
--- a/simulator/modules/sbot_interface/devices/motor.py
+++ b/simulator/modules/sbot_interface/devices/motor.py
@@ -119,7 +119,7 @@ class Motor(BaseMotor):
             else:
                 # Apply a small amount of variation to the power setting to simulate
                 # inaccuracies in the motor
-                value = int(add_jitter(value, (MIN_POWER, MAX_POWER)))
+                value = int(add_jitter(value, (MIN_POWER, MAX_POWER), std_dev_percent=1))
 
         self._device.setVelocity(map_to_range(
             value,

--- a/simulator/protos/robot/MotorAssembly.proto
+++ b/simulator/protos/robot/MotorAssembly.proto
@@ -49,7 +49,24 @@ PROTO MotorAssembly [
         device [
           RotationalMotor {
             name IS name
-            maxVelocity IS maxVelocity
+            %<
+              import * as wbrandom from 'wbrandom.js';
+              const motorVariation = 0.01;
+              // equivalent to Java's String.hashCode()
+              // https://gist.github.com/hyamamoto/fd435505d29ebfa3d9716fd2be8d42f0
+              function hashCode(s) {
+                var h = 0, l = s.length, i = 0;
+                if ( l > 0 )
+                  while (i < l)
+                    h = (h << 5) - h + s.charCodeAt(i++) | 0;
+                return h;
+              };
+              wbrandom.seed(hashCode(fields.name.value));
+              let motorCoeff = 1 + wbrandom.real() * motorVariation;
+            >%
+            # seed the random number generator with the name of the motor
+            # Add 1% variation between motors
+            maxVelocity %<= fields.maxVelocity.value * motorCoeff >%
             sound ""
           }
           PositionSensor {

--- a/simulator/protos/robot/MotorAssembly.proto
+++ b/simulator/protos/robot/MotorAssembly.proto
@@ -51,7 +51,7 @@ PROTO MotorAssembly [
             name IS name
             %<
               import * as wbrandom from 'wbrandom.js';
-              const motorVariation = 0.01;
+              const motorVariation = 0.015;
               // equivalent to Java's String.hashCode()
               // https://gist.github.com/hyamamoto/fd435505d29ebfa3d9716fd2be8d42f0
               function hashCode(s) {
@@ -65,7 +65,7 @@ PROTO MotorAssembly [
               let motorCoeff = 1 + wbrandom.real() * motorVariation;
             >%
             # seed the random number generator with the name of the motor
-            # Add 1% variation between motors
+            # Add 1.5% variation between motors
             maxVelocity %<= fields.maxVelocity.value * motorCoeff >%
             sound ""
           }


### PR DESCRIPTION
Adds a fixed 1% variation between motor instances
Seeded with motor name so all motors with the same name have the same error

This should be combined with reducing the motor jitter in the API.